### PR TITLE
chore: change @whiskeysockets/baileys to baileys

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "node": ">=18.16.0"
     },
     "dependencies": {
-        "@whiskeysockets/baileys": "^6.7.12",
+        "baileys": "^6.7.16",
         "axios": "^1.7.9",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",


### PR DESCRIPTION
> The new official package name for the Baileys package is "baileys". Please use that package name going forward. This version may stop receiving updates in the future.